### PR TITLE
Always delete scratch org

### DIFF
--- a/src/jobs/scratch-deploy.yml
+++ b/src/jobs/scratch-deploy.yml
@@ -79,3 +79,4 @@ steps:
   - run:
       name: Delete scratch org
       command: sfdx force:org:delete --noprompt
+      when: always


### PR DESCRIPTION
Currently when one of the run commands fail after a scratch org is created then the created scratch org is not deleted. The scratch org should always be deleted so that we cleanup properly after a run is triggered.