### PR TITLE
Updating sfdx cli download url

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -33,7 +33,7 @@ steps:
             name: Install SFDX - Standalone
             command: |
               cd /tmp
-              wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+              wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
               mkdir sfdx
               tar xJf sfdx-linux-amd64.tar.xz -C sfdx --strip-components 1
               ./sfdx/install

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -35,8 +35,9 @@ steps:
               cd /tmp
               wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
               mkdir sfdx
-              tar xJf sfdx-linux-amd64.tar.xz -C sfdx --strip-components 1
-              ./sfdx/install
+              tar xJf sfdx-linux-x64.tar.xz -C sfdx --strip-components 1
+              echo 'export PATH=./sfdx/bin/:$PATH' >> $BASH_ENV
+              source $BASH_ENV
   - run:
       name: Verify SFDX installation
       command: sfdx --version

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -36,7 +36,7 @@ steps:
               wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
               mkdir sfdx
               tar xJf sfdx-linux-x64.tar.xz -C sfdx --strip-components 1
-              echo 'export PATH=./sfdx/bin/:$PATH' >> $BASH_ENV
+              echo 'export PATH=./sfdx/bin:$PATH' >> $BASH_ENV
               source $BASH_ENV
   - run:
       name: Verify SFDX installation


### PR DESCRIPTION
fixes #24 
### Checklist

<!--
  Thank you for contributing to CircleCI Orbs!
  before submitting your request, please go through the following
  items and place an x in the [ ] if they have been completed.
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, Related Issues
Salesforce updated the sfdx install link in api docs version 51.0.  Old link is throwing a 403 error now.

[Old docs with old link](https://developer.salesforce.com/docs/atlas.en-us.228.0.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm)
[>=51.0 docs have new link](https://developer.salesforce.com/docs/atlas.en-us.230.0.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm)
<!---
  Why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
☝️ 
<!---
  Describe your changes in details, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
-->
