### PR TITLE
cleanup deprecated commands/paths

### DIFF
--- a/src/commands/auth.yml
+++ b/src/commands/auth.yml
@@ -71,8 +71,8 @@ steps:
   - run:
       name: Authenticate with Salesforce
       command: |
-        <<#parameters.instanceUrl>>sfdx force:config:set instanceUrl=<<parameters.instanceUrl>> --global<</parameters.instanceUrl>>
-        sfdx auth:jwt:grant --clientid $<<parameters.consumerKey>> \
-        --jwtkeyfile ./server.key --username <<parameters.defaultusername>> <<#parameters.instanceUrl>>--instanceurl <<parameters.instanceUrl>><</parameters.instanceUrl>> \
-        --setdefaultdevhubusername --setalias <<parameters.defaultdevhubusername>>
-        <<#parameters.apiVersion>>sfdx force:config:set apiVersion=<<parameters.apiVersion>><</parameters.apiVersion>>
+        <<#parameters.instanceUrl>>sfdx config:set instanceUrl=<<parameters.instanceUrl>> --global<</parameters.instanceUrl>>
+        sfdx auth:jwt:grant --client-id $<<parameters.consumerKey>> \
+        --jwt-key-file ./server.key --username <<parameters.defaultusername>> <<#parameters.instanceUrl>>--instance-url <<parameters.instanceUrl>><</parameters.instanceUrl>> \
+        --set-default-dev-hub --alias <<parameters.defaultdevhubusername>>
+        <<#parameters.apiVersion>>sfdx config:set apiVersion=<<parameters.apiVersion>><</parameters.apiVersion>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -33,10 +33,10 @@ steps:
             name: Install SFDX - Standalone
             command: |
               cd /tmp
-              wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+              wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
               mkdir sfdx
-              tar xJf sfdx-linux-amd64.tar.xz -C sfdx --strip-components 1
-              ./sfdx/install
+              tar xJf sfdx-linux-x64.tar.xz -C sfdx --strip-components 1
+              echo 'export PATH=/tmp/sfdx/bin:$PATH' >> "$BASH_ENV"
   - run:
       name: Verify SFDX installation
       command: sfdx --version

--- a/src/commands/scratch-create.yml
+++ b/src/commands/scratch-create.yml
@@ -17,5 +17,5 @@ steps:
   - run:
       name: Create << parameters.scratch-alias >> SalesForce Org
       command: |
-       sfdx force:org:create -f << parameters.scratch-config >> -a << parameters.scratch-alias >> <<# parameters.overrides >> << parameters.overrides >> <</ parameters.overrides >>
-       sfdx force:org:list | grep << parameters.scratch-alias >>
+        sfdx force:org:create -f << parameters.scratch-config >> -a << parameters.scratch-alias >> <<# parameters.overrides >> << parameters.overrides >> <</ parameters.overrides >>
+        sfdx org:list | grep << parameters.scratch-alias >>

--- a/src/commands/scratch-delete.yml
+++ b/src/commands/scratch-delete.yml
@@ -10,5 +10,5 @@ parameters:
 steps:
   - run:
       name: Delete <<# parameters.scratch-alias >><< parameters.scratch-alias >> <</ parameters.scratch-alias >>SalesForce Org
-      command: sfdx force:org:delete --noprompt <<# parameters.scratch-alias >> -u << parameters.scratch-alias >><</ parameters.scratch-alias >>
+      command: sfdx org:delete:scratch --noprompt <<# parameters.scratch-alias >> -u << parameters.scratch-alias >><</ parameters.scratch-alias >>
       when: always

--- a/src/commands/scratch-open.yml
+++ b/src/commands/scratch-open.yml
@@ -10,4 +10,4 @@ parameters:
 steps:
   - run:
       name: Open <<# parameters.scratch-alias >><< parameters.scratch-alias >> <</ parameters.scratch-alias >>SalesForce Org in browser
-      command: sfdx force:org:open <<# parameters.scratch-alias >> -u << parameters.scratch-alias >><</ parameters.scratch-alias >>
+      command: sfdx org:open <<# parameters.scratch-alias >> -u << parameters.scratch-alias >><</ parameters.scratch-alias >>


### PR DESCRIPTION
This crawls through the orb and ramps it up to the current salesforce cli:

- updates the download url for the Standalone install and changes the path
- updates deprecated flags

