### PR TITLE
[semver:major] Move to sf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
   integration-install_cli_npm_newer_node:
     docker:
-      - image: cimg/node:14.7
+      - image: cimg/node:current
     working_directory: ~/project
     steps:
       - sfdx/install:
@@ -43,7 +43,7 @@ jobs:
           defaultusername: gabriel@circleci.cpe
       - run:
           name: Check Auth List
-          command: sfdx auth:list
+          command: sf auth list
 
   integration-scratch_functions:
     executor: sfdx/default

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Ping these folks when changes are made to this repository
 * @CircleCI-Public/orb-publishers
 
-# We can also add orb-specifc codeowners at some point if desirable
+# We can also add orb-specific codeowners at some point if desirable

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Salesforce-sfdx orb [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/orb-starter-kit.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/orb-starter-kit) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
-Install, authenticate with, and utilize the Salesforce sfdx CLI on CircleCI with ease.
+Install, authenticate with, and utilize the Salesforce sf CLI on CircleCI with ease.
+
+> **Note**
+> This orb was updated in September 2023 to use the `sf` cli instead of `sfdx`
+> Commands are backwards compatible and you can call them using `sf` or `sfdx`
+> More information can be found [here](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_move_to_sf_v2.htm) on the developer.salesforce.com website
 
 ## Orb Registry
 
-Read the full automated documentation live on the Orb Registry: 
+Read the full automated documentation live on the Orb Registry: https://circleci.com/developer/orbs/orb/circleci/salesforce-sfdx#usage-create_open_delete_scratch
 
 ### Prerequisites
 
-1. [Enable Dev Hub](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_enable_devhub.htm)
+1. [Enable Dev Hub](https://help.salesforce.com/s/articleView?id=sf.sfdx_setup_enable_devhub.htm&type=5)
 2. [Create a private key with OpenSSL](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_key_and_cert.htm)
 3. [Create a connected app](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_connected_app.htm)
 
@@ -19,10 +24,11 @@ Navigate to the directory containing the self signed certificate files you creat
 **Add environment variables**
 
 https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
-* `SFDX_JWT_KEY`
-This value must contain the base64 encoded value of the private server.key file.
-* `SFDX_CONSUMER_KEY`
-The consumer key of the connected app for salesforce
+
+- `SFDX_JWT_KEY`
+  This value must contain the base64 encoded value of the private server.key file.
+- `SFDX_CONSUMER_KEY`
+  The consumer key of the connected app for salesforce
 
 ## Example
 
@@ -39,10 +45,10 @@ version: 2.1
         - sfdx/auth:
             defaultusername: user@email.com
         - run:
-            name: Run your SFDX commands here
+            name: Run your SF commands here
             command: |
-              echo "You now have access to the sfdx cli and may execute commands against it. https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference.htm"
-              sfdx auth:list
+              echo "You now have access to the sf cli and may execute commands against it. https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_unified.htm"
+              sf auth list
   workflows:
     basic-test:
       jobs:
@@ -52,4 +58,4 @@ version: 2.1
 
 ## Blog post
 
-Read our announcement post here: 
+Read our announcement post here:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: >
-  Salesforce SFDX CLI integration for CircleCI. Easily create CI/CD pipelines for your Salesforce integrations.
+  Salesforce SF CLI integration for CircleCI. Easily create CI/CD pipelines for your Salesforce integrations.
 
 display:
   home_url: https://github.com/CircleCI-Public/Salesforce-sfdx-cli-orb

--- a/src/commands/auth.yml
+++ b/src/commands/auth.yml
@@ -1,5 +1,5 @@
 description: >
-  Authenticate with and configure the SFDX CLI after installation.
+  Authenticate with and configure the SF CLI after installation.
   This orb utilizes JWT-based authentication. You will need to create a connected app and provide a base64 encoded server key for authentication.
   Learn more: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_jwt_flow.htm
 parameters:
@@ -7,7 +7,7 @@ parameters:
     description: The username for an org that all commands run against by default.
     type: string
   defaultdevhubusername:
-    description: The username of your Dev Hub org that the force:org:create command defaults to. Used as alias.
+    description: The username of your Dev Hub org that the 'org create scratch' command defaults to. Used as alias.
     default: "${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}"
     type: string
   jwtKey:
@@ -15,7 +15,7 @@ parameters:
     default: SFDX_JWT_KEY
     type: env_var_name
   consumerKey:
-    description: "The consumner key of the connected app for salesforce. Stored as an environment variable"
+    description: "The consumer key of the connected app for salesforce. Stored as an environment variable"
     default: SFDX_CONSUMER_KEY
     type: env_var_name
   instanceUrl:
@@ -23,11 +23,11 @@ parameters:
     default: ""
     type: string
   apiVersion:
-    description: The API version for a specific project or all projects. Normally, the Salesforce CLI assumes that you’re using the same version of the CLI as the Dev Hub org.
+    description: The API version for a specific project or all projects. Normally, the Salesforce CLI assumes that you're using the same version of the CLI as the Dev Hub org.
     default: ""
     type: string
   decryption_key:
-    description: Enviornment variable name for server.key decryption key, if available.
+    description: Environment variable name for server.key decryption key, if available.
     default: DECRYPTION_KEY
     type: env_var_name
   server_key:
@@ -44,7 +44,7 @@ steps:
             name: Check and install SFDC authentication key
             command: |
               if [ -z $<<parameters.jwtKey>> ]; then
-                echo "Authentication requires a base64 encoded server key to be provided as an evironment variable. Please ensure the <<parameters.jwtKey>> env var has been set correctly."
+                echo "Authentication requires a base64 encoded server key to be provided as an environment variable. Please ensure the <<parameters.jwtKey>> env var has been set correctly."
                 exit 1
               fi
               if [ -z $<<parameters.consumerKey>> ]; then
@@ -54,7 +54,7 @@ steps:
               echo Creating jwt key file.
               echo
               if [ -f ./server.key ]; then
-                echo "It appears you may have commited your server.key file. For your safety please never commit secrets to your code repository. We instead recommend utilizing environment variables for this purpose. You may wish to invalidate and regenerate your server key."
+                echo "It appears you may have committed your server.key file. For your safety please never commit secrets to your code repository. We instead recommend utilizing environment variables for this purpose. You may wish to invalidate and regenerate your server key."
                 exit 1
               fi
               echo $<<parameters.jwtKey>> | base64 --decode --ignore-garbage > ./server.key
@@ -71,8 +71,12 @@ steps:
   - run:
       name: Authenticate with Salesforce
       command: |
-        <<#parameters.instanceUrl>>sfdx force:config:set instanceUrl=<<parameters.instanceUrl>> --global<</parameters.instanceUrl>>
-        sfdx auth:jwt:grant --clientid $<<parameters.consumerKey>> \
-        --jwtkeyfile ./server.key --username <<parameters.defaultusername>> <<#parameters.instanceUrl>>--instanceurl <<parameters.instanceUrl>><</parameters.instanceUrl>> \
-        --setdefaultdevhubusername --setalias <<parameters.defaultdevhubusername>>
-        <<#parameters.apiVersion>>sfdx force:config:set apiVersion=<<parameters.apiVersion>><</parameters.apiVersion>>
+        <<#parameters.instanceUrl>>sf config set org-instance-url=<<parameters.instanceUrl>> --global<</parameters.instanceUrl>>
+        sf auth jwt grant \
+        --client-id $<<parameters.consumerKey>> \
+        --jwt-key-file ./server.key \
+        --username <<parameters.defaultusername>> \
+        <<#parameters.instanceUrl>>--instance-url <<parameters.instanceUrl>><</parameters.instanceUrl>> \
+        --set-default-dev-hub \
+        --alias <<parameters.defaultdevhubusername>>
+        <<#parameters.apiVersion>>sf config set org-api-version=<<parameters.apiVersion>><</parameters.apiVersion>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,11 +1,11 @@
 # How to author commands: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
 description: >
-  Install and configure the Salesforce "sfdx" cli utility giving access to the "sfdx" command.
-  Set parameters to automatically set the sfdx config values. Also able to be set via environment variables.
-  Learn more: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_config_values.htm
+  Install and configure the Salesforce "sf" cli utility giving access to the "sf" commands.
+  Set parameters to automatically set the sf config values. Also able to be set via environment variables.
+  Learn more: https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm
 parameters:
   version:
-    description: By default, the latest version of the standalone CLI will be installed. To install via npm, supply a version tag such as "latest" or "6".
+    description: By default, the latest version of the standalone CLI will be installed. To install via npm, supply a version tag such as "latest", "latest-rc", "nightly", "2.1.1", etc.
     default: ""
     type: string
 
@@ -15,7 +15,7 @@ steps:
       condition: <<parameters.version>>
       steps:
         - run:
-            name: Install SFDX - NPM
+            name: Install SF - NPM
             command: |
               command -v npm >/dev/null 2>&1 || { echo >&2 "NPM not installed in the current environment. Aborting."; exit 1; }
               if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we're root
@@ -24,19 +24,19 @@ steps:
                 fi
               fi
 
-              $SUDO npm install sfdx-cli@<<parameters.version>> --global
+              $SUDO npm install @salesforce/cli@<<parameters.version>> --global
   # unless version is _not_ defined.
   - unless:
       condition: <<parameters.version>>
       steps:
         - run:
-            name: Install SFDX - Standalone
+            name: Install SF - Standalone
             command: |
               cd /tmp
-              wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
-              mkdir sfdx
-              tar xJf sfdx-linux-amd64.tar.xz -C sfdx --strip-components 1
-              ./sfdx/install
+              wget https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.xz
+              mkdir sf
+              tar xJf sf-linux-x64.tar.xz -C sf --strip-components 1
+              echo 'export PATH=/tmp/sf/bin:$PATH' >> "$BASH_ENV"
   - run:
-      name: Verify SFDX installation
-      command: sfdx --version
+      name: Verify SF installation
+      command: sf --version

--- a/src/commands/scratch-create.yml
+++ b/src/commands/scratch-create.yml
@@ -1,4 +1,4 @@
-# Creates a scratch SFDX Org.
+# Creates a scratch Salesforce Org.
 description: >
   "Create a scratch Salesforce Org."
 parameters:
@@ -15,7 +15,7 @@ parameters:
 
 steps:
   - run:
-      name: Create << parameters.scratch-alias >> SalesForce Org
+      name: Create << parameters.scratch-alias >> Salesforce scratch org
       command: |
-       sfdx force:org:create -f << parameters.scratch-config >> -a << parameters.scratch-alias >> <<# parameters.overrides >> << parameters.overrides >> <</ parameters.overrides >>
-       sfdx force:org:list | grep << parameters.scratch-alias >>
+        sf org create scratch -f << parameters.scratch-config >> -a << parameters.scratch-alias >> <<# parameters.overrides >> << parameters.overrides >> <</ parameters.overrides >>
+        sf org list | grep << parameters.scratch-alias >>

--- a/src/commands/scratch-delete.yml
+++ b/src/commands/scratch-delete.yml
@@ -1,4 +1,4 @@
-# Delete a scratch SFDX Org.
+# Delete a scratch SF Org.
 description: >
   "Delete a scratch Salesforce Org."
 parameters:
@@ -9,6 +9,6 @@ parameters:
 
 steps:
   - run:
-      name: Delete <<# parameters.scratch-alias >><< parameters.scratch-alias >> <</ parameters.scratch-alias >>SalesForce Org
-      command: sfdx force:org:delete --noprompt <<# parameters.scratch-alias >> -u << parameters.scratch-alias >><</ parameters.scratch-alias >>
+      name: Delete <<# parameters.scratch-alias >><< parameters.scratch-alias >> <</ parameters.scratch-alias >>Salesforce scratch org
+      command: sf org delete scratch --no-prompt <<# parameters.scratch-alias >> --target-org << parameters.scratch-alias >><</ parameters.scratch-alias >>
       when: always

--- a/src/commands/scratch-open.yml
+++ b/src/commands/scratch-open.yml
@@ -9,5 +9,5 @@ parameters:
 
 steps:
   - run:
-      name: Open <<# parameters.scratch-alias >><< parameters.scratch-alias >> <</ parameters.scratch-alias >>SalesForce Org in browser
-      command: sfdx force:org:open <<# parameters.scratch-alias >> -u << parameters.scratch-alias >><</ parameters.scratch-alias >>
+      name: Open <<# parameters.scratch-alias >><< parameters.scratch-alias >> <</ parameters.scratch-alias >>Salesforce scratch org in browser
+      command: sf org open <<# parameters.scratch-alias >> --target-org << parameters.scratch-alias >><</ parameters.scratch-alias >>

--- a/src/examples/create_open_delete_scratch.yml
+++ b/src/examples/create_open_delete_scratch.yml
@@ -1,5 +1,5 @@
 description: >
-  Create, open then delete a scratch org.
+  Create, open, and then delete a scratch org.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/install_and_authenticate.yml
+++ b/src/examples/install_and_authenticate.yml
@@ -1,5 +1,5 @@
 description: >
-  Simple example showing how to install the Salesforce sfdx CLI with the default options and authenticate against it with JWT.
+  Simple example showing how to install the Salesforce sf CLI with the default options and authenticate against it with JWT.
 usage:
   version: 2.1
   orbs:
@@ -13,10 +13,10 @@ usage:
         - sfdx/auth:
             defaultusername: user@email.com
         - run:
-            name: Run your SFDX commands here
+            name: Run your SF commands here
             command: |
-              echo You now have access to the sfdx cli and may execute commands against it.
-              sfdx auth:list
+              echo You now have access to the sf cli and may execute commands against it.
+              sf auth list
   workflows:
     basic-test:
       jobs:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ docker:
   - image: "cimg/node:<<parameters.tag>>"
 parameters:
   tag:
-    default: "16.1"
+    default: "lts"
     description: >
       Pick a specific circleci/node image variant:
       https://hub.docker.com/r/cimg/node


### PR DESCRIPTION
Greetings 👋  I work on the Salesforce CLI team. 

The `sfdx` cli went into maintenance mode on July 12th ([post](https://github.com/forcedotcom/cli/issues/2132)). This PR replaces `sfdx` with the (backwards compatible) `sf` cli. 

A few notes: 
- I don’t know what all needs to be done to make a major version bump of this orb
- I updated the Node versions to use `lts` and `current` as documented [here](https://hub.docker.com/r/cimg/node#:~:text=This%20Node.js%20image%20has%20two%20version%20aliases%2C%20%22current%22%20and%20%22lts%22.%20This%20aliases%20will%20always%20point%20to%20the%20latest%20%22current%22%20and%20latest%20%22lts%22%20releases%20that%20Node.js%20has%20as%20according%20to%20their%20website)
- I check and updated all links
- I left the `SFDX_` prefix on the JWT env vars to prevent a folks from needing to change these in their settings. This will still work because we look up "scoped env vars" by bin aliases also ([change](https://github.com/oclif/core/pull/751/files#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755R419-R428))

Let me know if you need any other changes, thanks!